### PR TITLE
Create Spring Boot skeleton for dataSeeker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your OpenAI credentials
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-3.5-turbo

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target/
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,87 @@
 # dataSeeker
-Search data on a subject
+
+dataSeeker is a Spring Boot sample application that demonstrates how to retrieve and query documents on a chosen topic using LangChain4j and OpenAI models. The structure is inspired by the Cat Application and relies on Spring Boot, JDBC, and Thymeleaf.
+
+## 1. Maven project setup
+
+Create a standard Spring Boot project with a `pom.xml` that includes dependencies for:
+
+- `spring-boot-starter-web` – REST endpoints
+- `spring-boot-starter-jdbc` – database access
+- `spring-boot-starter-thymeleaf` – HTML views
+- `io.github.cdimascio:dotenv-java` – loads variables from a `.env` file
+- `dev.langchain4j:langchain4j` and `langchain4j-open-ai` – access OpenAI models
+
+A snippet of the dependencies section might look like:
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-jdbc</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>io.github.cdimascio</groupId>
+        <artifactId>dotenv-java</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-open-ai</artifactId>
+    </dependency>
+</dependencies>
+```
+
+Set the Java version and Spring Boot plugin in the build section as usual.
+
+## 2. `.env` configuration
+
+Store API secrets in a `.env` file in the project root:
+
+```
+OPENAI_API_KEY=your-openai-api-key
+OPENAI_MODEL=gpt-3.5-turbo
+```
+
+The `dotenv-java` library reads these variables so they can be injected as environment properties.
+
+## 3. Controllers and endpoints
+
+Implement a `DocumentController` that exposes REST endpoints for querying and managing documents:
+
+- `GET /search?query=term` – search stored documents by term and return an answer using LangChain4j with OpenAI.
+- `GET /documents/{id}` – retrieve an individual document.
+- `POST /documents` – add a document (for example, text or URL) to the repository and store embeddings for later queries.
+
+These endpoints interact with a service layer that handles document storage (via JDBC) and uses LangChain4j to build prompts or retrieval-augmented generation workflows.
+
+## 4. README instructions
+
+The README should document how to configure environment variables, build, and run the server.
+
+Typical usage:
+
+```bash
+# copy .env.example to .env and fill in your OpenAI credentials
+mvn clean package
+java -jar target/dataSeeker-0.0.1-SNAPSHOT.jar
+```
+
+During development you can also run:
+
+```bash
+mvn spring-boot:run
+```
+
+This plan should provide a basis for implementing the `dataSeeker` application with Spring Boot, LangChain4j, and OpenAI.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>dataSeeker</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>dataSeeker</name>
+    <description>Sample application using LangChain4j with Spring Boot</description>
+    <properties>
+        <java.version>17</java.version>
+        <spring-boot.version>3.2.4</spring-boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>0.29.0</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+            <version>0.29.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/dataseeker/DataSeekerApplication.java
+++ b/src/main/java/com/example/dataseeker/DataSeekerApplication.java
@@ -1,0 +1,14 @@
+package com.example.dataseeker;
+
+import io.github.cdimascio.dotenv.Dotenv;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DataSeekerApplication {
+    public static void main(String[] args) {
+        // Load environment variables from .env if present
+        Dotenv.configure().ignoreIfMissing().load();
+        SpringApplication.run(DataSeekerApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/dataseeker/controller/DocumentController.java
+++ b/src/main/java/com/example/dataseeker/controller/DocumentController.java
@@ -1,0 +1,43 @@
+package com.example.dataseeker.controller;
+
+import com.example.dataseeker.model.Document;
+import com.example.dataseeker.service.DocumentService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@Controller
+public class DocumentController {
+
+    private final DocumentService service;
+
+    public DocumentController(DocumentService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/")
+    public String index() {
+        return "index";
+    }
+
+    @GetMapping("/documents/{id}")
+    @ResponseBody
+    public Document getDocument(@PathVariable Long id) {
+        return service.findById(id).orElse(null);
+    }
+
+    @PostMapping("/documents")
+    @ResponseBody
+    public Document addDocument(@RequestBody Document doc) {
+        return service.save(doc);
+    }
+
+    @GetMapping("/search")
+    public String search(@RequestParam String query, Model model) {
+        String answer = service.search(query);
+        model.addAttribute("answer", answer);
+        return "index";
+    }
+}

--- a/src/main/java/com/example/dataseeker/model/Document.java
+++ b/src/main/java/com/example/dataseeker/model/Document.java
@@ -1,0 +1,30 @@
+package com.example.dataseeker.model;
+
+public class Document {
+    private Long id;
+    private String content;
+
+    public Document() {
+    }
+
+    public Document(Long id, String content) {
+        this.id = id;
+        this.content = content;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/dataseeker/repository/DocumentRepository.java
+++ b/src/main/java/com/example/dataseeker/repository/DocumentRepository.java
@@ -1,0 +1,32 @@
+package com.example.dataseeker.repository;
+
+import com.example.dataseeker.model.Document;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class DocumentRepository {
+
+    private final ConcurrentHashMap<Long, Document> store = new ConcurrentHashMap<>();
+    private long idSequence = 1L;
+
+    public List<Document> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    public Optional<Document> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    public Document save(Document doc) {
+        if (doc.getId() == null) {
+            doc.setId(idSequence++);
+        }
+        store.put(doc.getId(), doc);
+        return doc;
+    }
+}

--- a/src/main/java/com/example/dataseeker/service/DocumentService.java
+++ b/src/main/java/com/example/dataseeker/service/DocumentService.java
@@ -1,0 +1,57 @@
+package com.example.dataseeker.service;
+
+import com.example.dataseeker.model.Document;
+import com.example.dataseeker.repository.DocumentRepository;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.openai.OpenAiService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DocumentService {
+
+    private final DocumentRepository repository;
+    private OpenAiService openAiService;
+
+    @Value("${OPENAI_API_KEY:}")
+    private String apiKey;
+
+    @Value("${OPENAI_MODEL:gpt-3.5-turbo}")
+    private String model;
+
+    public DocumentService(DocumentRepository repository) {
+        this.repository = repository;
+    }
+
+    @PostConstruct
+    public void init() {
+        if (apiKey != null && !apiKey.isEmpty()) {
+            openAiService = OpenAiService.builder().apiKey(apiKey).modelName(model).build();
+        }
+    }
+
+    public Document save(Document doc) {
+        return repository.save(doc);
+    }
+
+    public Optional<Document> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    public List<Document> findAll() {
+        return repository.findAll();
+    }
+
+    public String search(String query) {
+        if (openAiService == null) {
+            return "OpenAI not configured";
+        }
+        // simple prompt for now
+        String prompt = "Find relevant information about: " + query;
+        return openAiService.generate(TextSegment.from(prompt)).content();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.main.banner-mode=off
+# Database configuration would go here

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>dataSeeker</title>
+</head>
+<body>
+<h1>dataSeeker</h1>
+<form action="/search" method="get">
+    <input type="text" name="query" placeholder="Enter search term"/>
+    <button type="submit">Search</button>
+</form>
+<div th:if="${answer}">
+    <h2>Answer</h2>
+    <p th:text="${answer}"></p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Maven pom with Spring Boot, LangChain4j and dotenv support
- scaffold application packages with a basic controller and service
- provide a simple index.html with a search form
- document environment variables and update README instructions

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842af8662cc8325affc2e7700cc5a57