### PR TITLE
Add document filtering and access

### DIFF
--- a/src/main/java/com/example/dataseeker/controller/DocumentController.java
+++ b/src/main/java/com/example/dataseeker/controller/DocumentController.java
@@ -1,7 +1,9 @@
 package com.example.dataseeker.controller;
 
 import com.example.dataseeker.model.Document;
+import com.example.dataseeker.model.DocumentType;
 import com.example.dataseeker.service.DocumentService;
+import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +20,8 @@ public class DocumentController {
     }
 
     @GetMapping("/")
-    public String index() {
+    public String index(Model model) {
+        model.addAttribute("documents", service.findAll());
         return "index";
     }
 
@@ -35,9 +38,10 @@ public class DocumentController {
     }
 
     @GetMapping("/search")
-    public String search(@RequestParam String query, Model model) {
-        String answer = service.search(query);
-        model.addAttribute("answer", answer);
+    public String search(@RequestParam String query,
+                         @RequestParam(value = "type", required = false) List<DocumentType> type,
+                         Model model) {
+        model.addAttribute("documents", service.search(query, type));
         return "index";
     }
 }

--- a/src/main/java/com/example/dataseeker/model/Document.java
+++ b/src/main/java/com/example/dataseeker/model/Document.java
@@ -2,13 +2,19 @@ package com.example.dataseeker.model;
 
 public class Document {
     private Long id;
+    private String name;
+    private DocumentType type;
+    private String url;
     private String content;
 
     public Document() {
     }
 
-    public Document(Long id, String content) {
+    public Document(Long id, String name, DocumentType type, String url, String content) {
         this.id = id;
+        this.name = name;
+        this.type = type;
+        this.url = url;
         this.content = content;
     }
 
@@ -18,6 +24,30 @@ public class Document {
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public DocumentType getType() {
+        return type;
+    }
+
+    public void setType(DocumentType type) {
+        this.type = type;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
     }
 
     public String getContent() {

--- a/src/main/java/com/example/dataseeker/model/DocumentType.java
+++ b/src/main/java/com/example/dataseeker/model/DocumentType.java
@@ -1,0 +1,6 @@
+package com.example.dataseeker.model;
+
+public enum DocumentType {
+    PDF,
+    HTML
+}

--- a/src/main/resources/static/sample.html
+++ b/src/main/resources/static/sample.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>Sample HTML</title></head>
+<body><p>This is a sample HTML file.</p></body>
+</html>

--- a/src/main/resources/static/sample.pdf
+++ b/src/main/resources/static/sample.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Hello PDF) Tj
+ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f
+0000000010 00000 n
+0000000053 00000 n
+0000000104 00000 n
+0000000193 00000 n
+trailer
+<< /Root 1 0 R /Size 5 >>
+startxref
+262
+%%EOF

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -8,11 +8,18 @@
 <h1>dataSeeker</h1>
 <form action="/search" method="get">
     <input type="text" name="query" placeholder="Enter search term"/>
+    <label><input type="checkbox" name="type" value="PDF"/> PDF</label>
+    <label><input type="checkbox" name="type" value="HTML"/> HTML</label>
     <button type="submit">Search</button>
 </form>
-<div th:if="${answer}">
-    <h2>Answer</h2>
-    <p th:text="${answer}"></p>
+
+<div th:if="${documents}">
+    <h2>Results</h2>
+    <ul>
+        <li th:each="doc : ${documents}">
+            <a th:href="@{${doc.url}}" th:text="${doc.name}"></a>
+        </li>
+    </ul>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow filtering of documents by type (PDF or HTML)
- show results list with links to files
- pre-populate example PDF/HTML documents

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ba67d8348325a713d167150002f0