### PR TITLE
Add unit tests and spring-boot-starter-test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>langchain4j-open-ai</artifactId>
             <version>0.29.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/example/dataseeker/controller/DocumentControllerTest.java
+++ b/src/test/java/com/example/dataseeker/controller/DocumentControllerTest.java
@@ -1,0 +1,51 @@
+package com.example.dataseeker.controller;
+
+import com.example.dataseeker.model.Document;
+import com.example.dataseeker.model.DocumentType;
+import com.example.dataseeker.service.DocumentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(DocumentController.class)
+class DocumentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DocumentService service;
+
+    @Test
+    void getDocumentReturnsDocument() throws Exception {
+        Document doc = new Document(1L, "test", DocumentType.PDF, "/d", "c");
+        when(service.findById(1L)).thenReturn(Optional.of(doc));
+
+        mockMvc.perform(get("/documents/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("test"));
+    }
+
+    @Test
+    void addDocumentReturnsSavedDocument() throws Exception {
+        Document doc = new Document(1L, "test", DocumentType.HTML, "/d", "c");
+        when(service.save(any(Document.class))).thenReturn(doc);
+
+        String json = "{\"name\":\"test\",\"type\":\"HTML\",\"url\":\"/d\",\"content\":\"c\"}";
+        mockMvc.perform(post("/documents")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L));
+    }
+}

--- a/src/test/java/com/example/dataseeker/repository/DocumentRepositoryTest.java
+++ b/src/test/java/com/example/dataseeker/repository/DocumentRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.example.dataseeker.repository;
+
+import com.example.dataseeker.model.Document;
+import com.example.dataseeker.model.DocumentType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocumentRepositoryTest {
+
+    @Test
+    void saveAndFindById() {
+        DocumentRepository repository = new DocumentRepository();
+        Document doc = new Document(null, "test", DocumentType.PDF, "/test.pdf", "content");
+        repository.save(doc);
+        assertNotNull(doc.getId());
+
+        Optional<Document> found = repository.findById(doc.getId());
+        assertTrue(found.isPresent());
+        assertEquals("test", found.get().getName());
+    }
+
+    @Test
+    void findAllReturnsSavedDocuments() {
+        DocumentRepository repository = new DocumentRepository();
+        repository.save(new Document(null, "d1", DocumentType.HTML, "/d1", "c1"));
+        repository.save(new Document(null, "d2", DocumentType.PDF, "/d2", "c2"));
+
+        assertEquals(2, repository.findAll().size());
+    }
+}

--- a/src/test/java/com/example/dataseeker/service/DocumentServiceTest.java
+++ b/src/test/java/com/example/dataseeker/service/DocumentServiceTest.java
@@ -1,0 +1,38 @@
+package com.example.dataseeker.service;
+
+import com.example.dataseeker.model.Document;
+import com.example.dataseeker.model.DocumentType;
+import com.example.dataseeker.repository.DocumentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocumentServiceTest {
+
+    private DocumentService service;
+
+    @BeforeEach
+    void setup() {
+        DocumentRepository repository = new DocumentRepository();
+        service = new DocumentService(repository);
+        // don't call init to avoid OpenAI init
+        service.save(new Document(null, "Java", DocumentType.PDF, "/java", "Java content"));
+        service.save(new Document(null, "Python", DocumentType.HTML, "/py", "Python content"));
+    }
+
+    @Test
+    void searchByQueryAndType() {
+        List<Document> result = service.search("Java", List.of(DocumentType.PDF));
+        assertEquals(1, result.size());
+        assertEquals("Java", result.get(0).getName());
+    }
+
+    @Test
+    void searchWithoutFiltersReturnsAll() {
+        List<Document> result = service.search("", null);
+        assertEquals(2, result.size());
+    }
+}


### PR DESCRIPTION
## Summary
- add spring-boot-starter-test dependency for Maven test scope
- implement unit tests for repository, service and controller

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bd147cdc8325b7a0ac3284b0e070