### PR TITLE
Add OpenAI query integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The `dotenv-java` library reads these variables so they can be injected as envir
 
 Implement a `DocumentController` that exposes REST endpoints for querying and managing documents:
 
-- `GET /search?query=term` – search stored documents by term and return an answer using LangChain4j with OpenAI.
+- `GET /search?query=term` – search stored documents by term. If OpenAI credentials are configured the service also returns an answer generated with LangChain4j.
 - `GET /documents/{id}` – retrieve an individual document.
 - `POST /documents` – add a document (for example, text or URL) to the repository and store embeddings for later queries.
 

--- a/src/main/java/com/example/dataseeker/controller/DocumentController.java
+++ b/src/main/java/com/example/dataseeker/controller/DocumentController.java
@@ -42,6 +42,7 @@ public class DocumentController {
                          @RequestParam(value = "type", required = false) List<DocumentType> type,
                          Model model) {
         model.addAttribute("documents", service.search(query, type));
+        model.addAttribute("answer", service.ask(query));
         return "index";
     }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -21,5 +21,9 @@
         </li>
     </ul>
 </div>
+<div th:if="${answer}">
+    <h2>Answer</h2>
+    <p th:text="${answer}"></p>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate LangChain4j based querying
- expose generated answer from `openAiService` on search endpoint
- display answer in the index view
- document new behaviour in README

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bd13e2a08325bc392c47dd3cb120