### PR TITLE
Use AtomicLong for ID generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>langchain4j-open-ai</artifactId>
             <version>0.29.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/dataseeker/repository/DocumentRepository.java
+++ b/src/main/java/com/example/dataseeker/repository/DocumentRepository.java
@@ -7,12 +7,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Repository
 public class DocumentRepository {
 
     private final ConcurrentHashMap<Long, Document> store = new ConcurrentHashMap<>();
-    private long idSequence = 1L;
+    private final AtomicLong idSequence = new AtomicLong(1);
 
     public List<Document> findAll() {
         return new ArrayList<>(store.values());
@@ -24,7 +25,7 @@ public class DocumentRepository {
 
     public Document save(Document doc) {
         if (doc.getId() == null) {
-            doc.setId(idSequence++);
+            doc.setId(idSequence.getAndIncrement());
         }
         store.put(doc.getId(), doc);
         return doc;

--- a/src/test/java/com/example/dataseeker/repository/DocumentRepositoryTest.java
+++ b/src/test/java/com/example/dataseeker/repository/DocumentRepositoryTest.java
@@ -1,0 +1,36 @@
+import com.example.dataseeker.model.Document;
+import com.example.dataseeker.repository.DocumentRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocumentRepositoryTest {
+
+    @Test
+    void concurrentSavesGenerateSequentialIds() throws Exception {
+        DocumentRepository repo = new DocumentRepository();
+        int tasks = 50;
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        List<Future<Document>> futures = new CopyOnWriteArrayList<>();
+        for (int i = 0; i < tasks; i++) {
+            futures.add(executor.submit(() -> repo.save(new Document())));
+        }
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+
+        Set<Long> ids = new HashSet<>();
+        for (Future<Document> f : futures) {
+            ids.add(f.get().getId());
+        }
+        assertEquals(tasks, ids.size());
+        for (long i = 1; i <= tasks; i++) {
+            assertTrue(ids.contains(i));
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- make the document ID sequence an `AtomicLong`
- set new IDs using `getAndIncrement()`
- add JUnit test verifying concurrent saves
- include Spring Boot test dependency

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bd11b2088325959266270f505043