### PR TITLE
Add LLM link search

### DIFF
--- a/src/main/java/com/example/dataseeker/controller/DocumentController.java
+++ b/src/main/java/com/example/dataseeker/controller/DocumentController.java
@@ -42,7 +42,13 @@ public class DocumentController {
                          @RequestParam(value = "type", required = false) List<DocumentType> type,
                          Model model) {
         model.addAttribute("documents", service.search(query, type));
-        model.addAttribute("answer", service.ask(query));
+        String answer;
+        if (type != null && !type.isEmpty()) {
+            answer = service.askForLinks(query, type);
+        } else {
+            answer = service.ask(query);
+        }
+        model.addAttribute("answer", answer);
         return "index";
     }
 }

--- a/src/main/java/com/example/dataseeker/service/DocumentService.java
+++ b/src/main/java/com/example/dataseeker/service/DocumentService.java
@@ -65,6 +65,37 @@ public class DocumentService {
     }
 
     /**
+     * Ask OpenAI to provide a list of links to the requested document types about the given query.
+     * This returns {@code null} if the OpenAI service is not configured.
+     */
+    public String askForLinks(String query, List<DocumentType> types) {
+        if (openAiService == null || query == null || query.isBlank()) {
+            return null;
+        }
+
+        String typeDescription;
+        if (types == null || types.isEmpty()) {
+            typeDescription = "relevant web pages";
+        } else {
+            typeDescription = types.stream()
+                    .map(t -> t == DocumentType.PDF ? "PDF files" : "HTML pages")
+                    .collect(Collectors.joining(" and "));
+        }
+
+        String prompt = "Provide a list of direct links to " + typeDescription +
+                " about \"" + query + "\". " +
+                "Format the response as bullet points with one link per line.";
+        return openAiService.generate(prompt);
+    }
+
+    /**
+     * @return {@code true} if the OpenAI service is configured and available.
+     */
+    public boolean isOpenAiConfigured() {
+        return openAiService != null;
+    }
+
+    /**
      * Ask OpenAI to answer the given query based on all stored documents.
      * The answer will only be generated if the OpenAI service is configured.
      */

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -22,8 +22,8 @@
     </ul>
 </div>
 <div th:if="${answer}">
-    <h2>Answer</h2>
-    <p th:text="${answer}"></p>
+    <h2>Assistant Response</h2>
+    <pre th:text="${answer}"></pre>
 </div>
 </body>
 </html>

--- a/src/test/java/com/example/dataseeker/service/DocumentServiceTest.java
+++ b/src/test/java/com/example/dataseeker/service/DocumentServiceTest.java
@@ -35,4 +35,9 @@ class DocumentServiceTest {
         List<Document> result = service.search("", null);
         assertEquals(2, result.size());
     }
+
+    @Test
+    void askForLinksReturnsNullWhenNoOpenAiService() {
+        assertNull(service.askForLinks("java", List.of(DocumentType.PDF)));
+    }
 }


### PR DESCRIPTION
## Summary
- integrate OpenAI prompt for link retrieval
- delegate link search through `DocumentService.askForLinks`
- display assistant output in the UI
- test `askForLinks` when OpenAI is not configured

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d7d529f0832586722cada8fad7f4