### PR TITLE
Use env API_KEY and MODEL_NAME

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # Copy this file to .env and fill in your OpenAI credentials
-OPENAI_API_KEY=
-OPENAI_MODEL=gpt-3.5-turbo
+API_KEY=
+MODEL_NAME=gpt-3.5-turbo

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Set the Java version and Spring Boot plugin in the build section as usual.
 Store API secrets in a `.env` file in the project root:
 
 ```
-OPENAI_API_KEY=your-openai-api-key
-OPENAI_MODEL=gpt-3.5-turbo
+API_KEY=your-openai-api-key
+MODEL_NAME=gpt-3.5-turbo
 ```
 
 The `dotenv-java` library reads these variables so they can be injected as environment properties.
@@ -71,7 +71,7 @@ The README should document how to configure environment variables, build, and ru
 Typical usage:
 
 ```bash
-# copy .env.example to .env and fill in your OpenAI credentials
+# copy .env.example to .env and set your API key and model name
 mvn clean package
 java -jar target/dataSeeker-0.0.1-SNAPSHOT.jar
 ```

--- a/src/main/java/com/example/dataseeker/service/DocumentService.java
+++ b/src/main/java/com/example/dataseeker/service/DocumentService.java
@@ -19,10 +19,10 @@ public class DocumentService {
     private final DocumentRepository repository;
     private OpenAiChatModel openAiService;
 
-    @Value("${OPENAI_API_KEY:}")
+    @Value("${API_KEY:}")
     private String apiKey;
 
-    @Value("${OPENAI_MODEL:gpt-3.5-turbo}")
+    @Value("${MODEL_NAME:gpt-3.5-turbo}")
     private String model;
 
     public DocumentService(DocumentRepository repository) {


### PR DESCRIPTION
## Summary
- update service to read `API_KEY` and `MODEL_NAME`
- update example `.env`
- document environment variables in README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842de6a833c8325ada1909582777721