### PR TITLE
Add MCP prompt optimizer tool

### DIFF
--- a/src/main/java/com/example/dataseeker/agent/PromptOptimizerAgent.java
+++ b/src/main/java/com/example/dataseeker/agent/PromptOptimizerAgent.java
@@ -1,14 +1,31 @@
 package com.example.dataseeker.agent;
 
 import com.example.dataseeker.tool.PromptOptimizerTool;
+import dev.langchain4j.messenger.StdioMessenger;
+import dev.langchain4j.mcp.McpClient;
+import dev.langchain4j.agent.tool.Tools;
 import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
 
 @Component
 public class PromptOptimizerAgent {
+
     private final PromptOptimizerTool tool;
+    private McpClient client;
 
     public PromptOptimizerAgent(PromptOptimizerTool tool) {
         this.tool = tool;
+    }
+
+    @PostConstruct
+    public void startClient() {
+        Tools tools = Tools.builder().add(tool).build();
+        client = McpClient.builder()
+                .tools(tools)
+                .messenger(new StdioMessenger())
+                .build();
+        client.start();
     }
 
     public String optimize(String prompt) {

--- a/src/main/java/com/example/dataseeker/tool/PromptOptimizerTool.java
+++ b/src/main/java/com/example/dataseeker/tool/PromptOptimizerTool.java
@@ -1,14 +1,31 @@
 package com.example.dataseeker.tool;
 
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
 import org.springframework.stereotype.Component;
 
 /**
- * Simulates a tool that optimizes prompts via MCP protocol.
+ * Tool that optimizes a prompt written in Markdown using an LLM.
  */
 @Component
 public class PromptOptimizerTool {
+
+    private final ChatLanguageModel model;
+
+    public PromptOptimizerTool() {
+        this(OpenAiChatModel.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .build());
+    }
+
+    public PromptOptimizerTool(ChatLanguageModel model) {
+        this.model = model;
+    }
+
+    @Tool("Optimize a Markdown prompt")
     public String optimize(String prompt) {
-        // in real implementation, connect via MCP
-        return "[Optimized] " + prompt;
+        String instruction = "Improve the following prompt and answer only with the optimized Markdown";
+        return model.generate(instruction + "\n\n" + prompt);
     }
 }


### PR DESCRIPTION
## Summary
- add `PromptOptimizerTool` that uses an LLM to produce optimized markdown prompts
- expose `PromptOptimizerAgent` as an MCP client so tools can run via the protocol

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685436eb11cc832598f682784d6d63fd