### PR TITLE
Update LangChain4j dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,12 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>0.29.0</version>
+            <version>1.0.0-beta4</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>0.29.0</version>
+            <version>1.0.0-beta4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- update langChain4j and langChain4j-open-ai to `1.0.0-beta4`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854397320f883258b11a6f50492a0c8