### PR TITLE
Update to McpClient for LangChain4j 1.1.0

### DIFF
--- a/src/main/java/com/example/dataseeker/agent/PromptOptimizerAgent.java
+++ b/src/main/java/com/example/dataseeker/agent/PromptOptimizerAgent.java
@@ -2,7 +2,7 @@ package com.example.dataseeker.agent;
 
 import com.example.dataseeker.tool.PromptOptimizerTool;
 import dev.langchain4j.messenger.console.StdioMessenger;
-import dev.langchain4j.mcp.McpWsClient;
+import dev.langchain4j.mcp.McpClient;
 import dev.langchain4j.agent.tool.Tools;
 import org.springframework.stereotype.Component;
 
@@ -12,7 +12,7 @@ import jakarta.annotation.PostConstruct;
 public class PromptOptimizerAgent {
 
     private final PromptOptimizerTool tool;
-    private McpWsClient client;
+    private McpClient client;
 
     public PromptOptimizerAgent(PromptOptimizerTool tool) {
         this.tool = tool;
@@ -21,7 +21,7 @@ public class PromptOptimizerAgent {
     @PostConstruct
     public void startClient() {
         Tools tools = Tools.builder().add(tool).build();
-        client = McpWsClient.builder()
+        client = McpClient.builder()
                 .tools(tools)
                 .messenger(new StdioMessenger())
                 .build();


### PR DESCRIPTION
## Summary
- use `McpClient` instead of deprecated `McpWsClient`

## Testing
- `mvn -v` *(fails: command not found)*
- `./mvnw -v` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68543e5f03f8832593b52295c13db7c9